### PR TITLE
Add two-stage Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+ARG BIN_NAME=flickr-exporter
+ARG BIN_VERSION=<unknown>
+
+FROM golang:1-alpine AS builder
+ARG BIN_NAME
+ARG BIN_VERSION
+WORKDIR /src/flickr-exporter
+COPY . .
+RUN CGO_ENABLED=0 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME} .
+
+FROM alpine:latest
+ARG BIN_NAME
+RUN apk add --no-cache ca-certificates perl exiftool
+COPY --from=builder /src/flickr-exporter/out/${BIN_NAME} /usr/bin/flickr-exporter
+ENTRYPOINT ["/usr/bin/flickr-exporter"]
+
+LABEL license="GPL-3.0"
+LABEL maintainer="Chris Dzombak <https://www.dzombak.com>"
+LABEL org.opencontainers.image.authors="Chris Dzombak <https://www.dzombak.com>"
+LABEL org.opencontainers.image.url="https://github.com/cdzombak/flickr-exporter"
+LABEL org.opencontainers.image.documentation="https://github.com/cdzombak/flickr-exporter/blob/main/README.md"
+LABEL org.opencontainers.image.source="https://github.com/cdzombak/flickr-exporter.git"
+LABEL org.opencontainers.image.version="${BIN_VERSION}"
+LABEL org.opencontainers.image.licenses="GPL-3.0"
+LABEL org.opencontainers.image.title="${BIN_NAME}"
+LABEL org.opencontainers.image.description="A command-line tool to download and archive your Flickr photos with metadata preservation"

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN CGO_ENABLED=0 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${
 
 FROM alpine:latest
 ARG BIN_NAME
+ARG BIN_VERSION
 RUN apk add --no-cache ca-certificates perl exiftool
 COPY --from=builder /src/flickr-exporter/out/${BIN_NAME} /usr/bin/flickr-exporter
 ENTRYPOINT ["/usr/bin/flickr-exporter"]


### PR DESCRIPTION
## Summary

Adds a two-stage Dockerfile following the conventions of other repos in this org (e.g. `ecobee_influx_connector`, `mastodon-post`):

- **Stage 1 (builder):** `golang:1-alpine` — compiles a static binary with `CGO_ENABLED=0`
- **Stage 2 (runtime):** `alpine:latest` — installs `exiftool`, `perl`, and `ca-certificates` since the app shells out to `exiftool` at runtime via `go-exiftool`

Uses `alpine:latest` instead of `scratch` for the runtime stage because `exiftool` (a Perl script) is a required runtime dependency.

OCI labels follow the same pattern as other repos in this org.

### Updates since last revision

- Added `ARG BIN_VERSION` re-declaration in the runtime stage so the `org.opencontainers.image.version` label is correctly populated (was missing, causing the label to be empty).

## Review & Testing Checklist for Human

- [ ] The `-X main.version=${BIN_VERSION}` ldflag is included for consistency with other repos, but `main.go` doesn't currently declare a `version` variable — confirm this is desired (it's a no-op until one is added).
- [ ] Verify `perl` isn't redundant in the `apk add` line — `exiftool` on Alpine may already pull it in as a dependency. Not harmful either way, just a style question.
- [ ] Consider whether a `.dockerignore` should be added to exclude `.git/`, `.idea/`, etc. from the build context. Not a correctness issue since multi-stage build discards the builder, but it would speed up builds.
- [ ] Build and run: `docker build -t flickr-exporter . && docker run --rm flickr-exporter --help` to verify the binary and exiftool are both functional.

### Notes

- The image was successfully built and tested locally — `flickr-exporter --help` runs correctly inside the container.

Link to Devin session: https://app.devin.ai/sessions/71e235c8e7ea423da78d22b5d14c14c6
Requested by: @cdzombak
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cdzombak/flickr-exporter/pull/3" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker containerization support added for easy build and deploy.
  * Optimized multi-stage image for a smaller runtime artifact.
  * Runtime includes required dependencies (TLS certs, Perl, EXIF tooling) so the app runs out-of-the-box.
  * Container is configured to run the application automatically on start and exposes image metadata for discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->