### PR TITLE
Add build-time version injection and `--version` flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 creds.yml
 flickr-exporter
 flickr-export
+out/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 creds.yml
 flickr-exporter
 flickr-export
-out/

--- a/.version.sh
+++ b/.version.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ -z "$(git tag --points-at HEAD)" ]; then
+	git describe --always --long --dirty | sed 's/^v//'
+else
+	git tag --points-at HEAD | sed 's/^v//' | awk '{ print length, $0 }' | sort -n -s | cut -d" " -f2- | tail -n 1
+fi

--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,63 @@
-# Makefile for flickr-exporter
+SHELL:=/usr/bin/env bash
 
-# Binary name
-BINARY = flickr-exporter
+# nb. homebrew-releaser assumes the program name is == the repository name
+BIN_NAME:=flickr-exporter
+BIN_VERSION:=$(shell ./.version.sh)
 
-# Go parameters
-GOCMD = go
-GOBUILD = $(GOCMD) build
-GOCLEAN = $(GOCMD) clean
+default: help
+.PHONY: help  # via https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
+help: ## Print help
+	@grep -E '^[a-zA-Z_-/]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-# Build target
-all: build
+.PHONY: all
+all: clean build-linux-amd64 build-linux-arm64 build-linux-386 build-linux-armv7 build-linux-armv6 build-darwin-amd64 build-darwin-arm64 ## Build for macOS (amd64, arm64) and Linux (amd64, 386, arm64, armv7, armv6)
 
-build:
-	$(GOBUILD) -o $(BINARY) -v
+.PHONY: clean
+clean: ## Remove build products (./out)
+	rm -rf ./out
 
-# Clean target - removes only the binary, not downloaded photos
-clean:
-	$(GOCLEAN)
-	rm -f $(BINARY)
+.PHONY: build
+build: ## Build for the current platform & architecture to ./out
+	mkdir -p out
+	env CGO_ENABLED=0 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME} .
 
-.PHONY: all build clean
+.PHONY: build-linux-amd64
+build-linux-amd64: ## Build for Linux/amd64 to ./out
+	mkdir -p out
+	env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME}-${BIN_VERSION}-linux-amd64 .
+
+.PHONY: build-linux-arm64
+build-linux-arm64: ## Build for Linux/arm64 to ./out
+	mkdir -p out
+	env CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME}-${BIN_VERSION}-linux-arm64 .
+
+.PHONY: build-linux-386
+build-linux-386: ## Build for Linux/386 to ./out
+	mkdir -p out
+	env CGO_ENABLED=0 GOOS=linux GOARCH=386 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME}-${BIN_VERSION}-linux-386 .
+
+.PHONY: build-linux-armv7
+build-linux-armv7: ## Build for Linux/armv7 to ./out
+	mkdir -p out
+	env CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=7 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME}-${BIN_VERSION}-linux-armv7 .
+
+.PHONY: build-linux-armv6
+build-linux-armv6: ## Build for Linux/armv6 to ./out
+	mkdir -p out
+	env CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME}-${BIN_VERSION}-linux-armv6 .
+
+.PHONY: build-darwin-amd64
+build-darwin-amd64: ## Build for macOS/amd64 to ./out
+	mkdir -p out
+	env CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME}-${BIN_VERSION}-darwin-amd64 .
+
+.PHONY: build-darwin-arm64
+build-darwin-arm64: ## Build for macOS/arm64 to ./out
+	mkdir -p out
+	env CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME}-${BIN_VERSION}-darwin-arm64 .
+
+.PHONY: package
+package: all ## Build all binaries + .deb packages to ./out (requires fpm: https://fpm.readthedocs.io)
+	fpm -t deb -v ${BIN_VERSION} -p ./out/${BIN_NAME}-${BIN_VERSION}-amd64.deb -a amd64 ./out/${BIN_NAME}-${BIN_VERSION}-linux-amd64=/usr/bin/${BIN_NAME}
+	fpm -t deb -v ${BIN_VERSION} -p ./out/${BIN_NAME}-${BIN_VERSION}-arm64.deb -a arm64 ./out/${BIN_NAME}-${BIN_VERSION}-linux-arm64=/usr/bin/${BIN_NAME}
+	fpm -t deb -v ${BIN_VERSION} -p ./out/${BIN_NAME}-${BIN_VERSION}-armhf.deb -a armhf ./out/${BIN_NAME}-${BIN_VERSION}-linux-armv6=/usr/bin/${BIN_NAME}

--- a/Makefile
+++ b/Makefile
@@ -1,63 +1,23 @@
-SHELL:=/usr/bin/env bash
+# Makefile for flickr-exporter
 
-# nb. homebrew-releaser assumes the program name is == the repository name
-BIN_NAME:=flickr-exporter
-BIN_VERSION:=$(shell ./.version.sh)
+# Binary name
+BINARY = flickr-exporter
+BIN_VERSION := $(shell ./.version.sh)
 
-default: help
-.PHONY: help  # via https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
-help: ## Print help
-	@grep -E '^[a-zA-Z_-/]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+# Go parameters
+GOCMD = go
+GOBUILD = $(GOCMD) build
+GOCLEAN = $(GOCMD) clean
 
-.PHONY: all
-all: clean build-linux-amd64 build-linux-arm64 build-linux-386 build-linux-armv7 build-linux-armv6 build-darwin-amd64 build-darwin-arm64 ## Build for macOS (amd64, arm64) and Linux (amd64, 386, arm64, armv7, armv6)
+# Build target
+all: build
 
-.PHONY: clean
-clean: ## Remove build products (./out)
-	rm -rf ./out
+build:
+	$(GOBUILD) -ldflags="-X main.version=$(BIN_VERSION)" -o $(BINARY) -v
 
-.PHONY: build
-build: ## Build for the current platform & architecture to ./out
-	mkdir -p out
-	env CGO_ENABLED=0 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME} .
+# Clean target - removes only the binary, not downloaded photos
+clean:
+	$(GOCLEAN)
+	rm -f $(BINARY)
 
-.PHONY: build-linux-amd64
-build-linux-amd64: ## Build for Linux/amd64 to ./out
-	mkdir -p out
-	env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME}-${BIN_VERSION}-linux-amd64 .
-
-.PHONY: build-linux-arm64
-build-linux-arm64: ## Build for Linux/arm64 to ./out
-	mkdir -p out
-	env CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME}-${BIN_VERSION}-linux-arm64 .
-
-.PHONY: build-linux-386
-build-linux-386: ## Build for Linux/386 to ./out
-	mkdir -p out
-	env CGO_ENABLED=0 GOOS=linux GOARCH=386 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME}-${BIN_VERSION}-linux-386 .
-
-.PHONY: build-linux-armv7
-build-linux-armv7: ## Build for Linux/armv7 to ./out
-	mkdir -p out
-	env CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=7 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME}-${BIN_VERSION}-linux-armv7 .
-
-.PHONY: build-linux-armv6
-build-linux-armv6: ## Build for Linux/armv6 to ./out
-	mkdir -p out
-	env CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME}-${BIN_VERSION}-linux-armv6 .
-
-.PHONY: build-darwin-amd64
-build-darwin-amd64: ## Build for macOS/amd64 to ./out
-	mkdir -p out
-	env CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME}-${BIN_VERSION}-darwin-amd64 .
-
-.PHONY: build-darwin-arm64
-build-darwin-arm64: ## Build for macOS/arm64 to ./out
-	mkdir -p out
-	env CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME}-${BIN_VERSION}-darwin-arm64 .
-
-.PHONY: package
-package: all ## Build all binaries + .deb packages to ./out (requires fpm: https://fpm.readthedocs.io)
-	fpm -t deb -v ${BIN_VERSION} -p ./out/${BIN_NAME}-${BIN_VERSION}-amd64.deb -a amd64 ./out/${BIN_NAME}-${BIN_VERSION}-linux-amd64=/usr/bin/${BIN_NAME}
-	fpm -t deb -v ${BIN_VERSION} -p ./out/${BIN_NAME}-${BIN_VERSION}-arm64.deb -a arm64 ./out/${BIN_NAME}-${BIN_VERSION}-linux-arm64=/usr/bin/${BIN_NAME}
-	fpm -t deb -v ${BIN_VERSION} -p ./out/${BIN_NAME}-${BIN_VERSION}-armhf.deb -a armhf ./out/${BIN_NAME}-${BIN_VERSION}-linux-armv6=/usr/bin/${BIN_NAME}
+.PHONY: all build clean

--- a/main.go
+++ b/main.go
@@ -37,15 +37,6 @@ Supports exporting single albums, collections, or all photos.
 Photos are organized by album with date prefixes and include EXIF/IPTC metadata.`,
 }
 
-var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Print version information and exit",
-	Args:  cobra.NoArgs,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("flickr-exporter %s\n", version)
-	},
-}
-
 var authCmd = &cobra.Command{
 	Use:   "auth",
 	Short: "Authenticate with Flickr to get OAuth tokens",
@@ -325,8 +316,9 @@ func init() {
 	// Auth command specific flags
 	authCmd.Flags().StringVar(&credsFileSave, "save-creds", "", "Save credentials to this YAML file")
 
+	rootCmd.Version = version
+
 	// Add subcommands
-	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(authCmd)
 	rootCmd.AddCommand(albumCmd)
 	rootCmd.AddCommand(collectionCmd)

--- a/main.go
+++ b/main.go
@@ -9,6 +9,8 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+var version = "<dev>"
+
 var (
 	apiKey           string
 	apiSecret        string
@@ -33,6 +35,15 @@ var rootCmd = &cobra.Command{
 	Long: `A tool to export original-resolution photos from your Flickr account.
 Supports exporting single albums, collections, or all photos.
 Photos are organized by album with date prefixes and include EXIF/IPTC metadata.`,
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print version information and exit",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("flickr-exporter %s\n", version)
+	},
 }
 
 var authCmd = &cobra.Command{
@@ -315,6 +326,7 @@ func init() {
 	authCmd.Flags().StringVar(&credsFileSave, "save-creds", "", "Save credentials to this YAML file")
 
 	// Add subcommands
+	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(authCmd)
 	rootCmd.AddCommand(albumCmd)
 	rootCmd.AddCommand(collectionCmd)


### PR DESCRIPTION
## Summary

Adds build-time version injection to `flickr-exporter` following the same pattern used in [lychee-ai-organizer](https://github.com/cdzombak/lychee-ai-organizer), as requested in #2.

**Go changes (`main.go`):**
- Added `var version = "<dev>"` which is overwritten at build time via `-ldflags "-X main.version=..."`
- Set `rootCmd.Version = version` so cobra provides a `--version` flag (e.g. `flickr-exporter --version` prints `flickr-exporter version <version>`)

**Build system changes:**
- Added `.version.sh` (copied from lychee-ai-organizer) to derive version from git tags
- Added `BIN_VERSION` variable and `-ldflags` to the existing Makefile `build` target — no other Makefile changes

## Review & Testing Checklist for Human

- [ ] **Test locally**: `make build && ./flickr-exporter --version` — verify it prints a version string (e.g. `flickr-exporter version <commit>-dirty`). After tagging a release, verify it prints the tag version.
- [ ] **Version output format**: Cobra's default format is `flickr-exporter version <version>` (not just the version string). Verify this is acceptable, or if you'd prefer a different format.
- [ ] **`.version.sh` behavior without tags**: If the repo has no tags, `git describe --always --long --dirty` will output just a commit hash. Verify this is acceptable for dev builds.

### Notes

- There is no CI configured for this repo, so there are no automated checks to run.
- The `.version.sh` script is identical to the one in lychee-ai-organizer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--version` flag support to display application version information.

* **Chores**
  * Updated build system to automatically embed version metadata derived from Git state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Link to Devin session: https://app.devin.ai/sessions/ccddff8ea67a4da188e4351d4d41d21e
Requested by: @cdzombak