### PR TITLE
Add GitHub Actions CI workflow with build, package, and release support

### DIFF
--- a/.fpm
+++ b/.fpm
@@ -1,0 +1,6 @@
+-s dir
+--name flickr-exporter
+--description "A command-line tool to download and archive your Flickr photos with metadata preservation"
+--url "https://github.com/cdzombak/flickr-exporter"
+--maintainer "Chris Dzombak <https://www.dzombak.com>"
+--license GPL-3.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -323,7 +323,7 @@ jobs:
           target_linux_arm64: true
           version: v${{ needs.meta.outputs.bin_version }}
           install: 'bin.install "${{ needs.meta.outputs.bin_name }}"'
-          test: 'assert_match("${{ needs.meta.outputs.bin_version }}", shell_output("#{bin}/${{ needs.meta.outputs.bin_name }} -version"))'
+          test: 'assert_match("${{ needs.meta.outputs.bin_version }}", shell_output("#{bin}/${{ needs.meta.outputs.bin_name }} --version"))'
 
   ntfy:
     name: Ntfy

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,355 @@
+---
+name: CI
+
+"on":
+  push:
+    branches:
+      - "main"
+    tags:
+      - "v*.*.*"
+  pull_request:
+    branches:
+      - "main"
+
+permissions:
+  contents: read
+
+env:
+  DOCKER_PLATFORMS: "linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6"
+  FPM_VERSION: 1.15.1
+
+jobs:
+  meta:
+    name: Derive Build Metadata
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Derive version string
+        id: bin_version
+        run: echo "bin_version=$(./.version.sh)" >> "$GITHUB_OUTPUT"
+      - name: bin_version
+        run: "echo bin_version: ${{ steps.bin_version.outputs.bin_version }}"
+      - name: Check if this is a running version tag update
+        id: running_version_tag
+        run: |
+          if [ -z "${{ github.event.ref }}" ]; then
+              echo "is_running_version_tag_update=false" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event.ref }}" =~ ^refs/tags/v[0-9]+\.[0-9]+$ ]]; then
+              echo "is_running_version_tag_update=true" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ github.event.ref }}" =~ ^refs/tags/v[0-9]+$ ]]; then
+              echo "is_running_version_tag_update=true" >> "$GITHUB_OUTPUT"
+          else
+              echo "is_running_version_tag_update=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: is_running_version_tag
+        run: "echo is_running_version_tag_update: ${{ steps.running_version_tag.outputs.is_running_version_tag_update }}"
+    outputs:
+      # nb. homebrew-releaser assumes the program name is == the repository name
+      bin_name: ${{ github.event.repository.name }}
+      bin_version: ${{ steps.bin_version.outputs.bin_version }}
+      dockerhub_owner: ${{ github.repository_owner }}
+      ghcr_owner: ${{ github.repository_owner }}
+      aptly_repo_name: oss
+      aptly_dist: any
+      aptly_publish_prefix: s3:dist.cdzombak.net:deb_oss
+      brewtap_owner: ${{ github.repository_owner }}
+      brewtap_name: oss
+      brewtap_formula_dir: Formula
+      is_prerelease: >-
+        ${{
+          steps.running_version_tag.outputs.is_running_version_tag_update != 'true' &&
+          startsWith(github.ref, 'refs/tags/v') &&
+            (contains(github.ref, '-alpha.')
+            || contains(github.ref, '-beta.')
+            || contains(github.ref, '-rc.'))
+        }}
+      is_release: >-
+        ${{
+          steps.running_version_tag.outputs.is_running_version_tag_update != 'true' &&
+          startsWith(github.ref, 'refs/tags/v') &&
+            !(contains(github.ref, '-alpha.')
+            || contains(github.ref, '-beta.')
+            || contains(github.ref, '-rc.'))
+        }}
+      is_pull_request: ${{ github.event_name == 'pull_request' }}
+      is_running_version_tag_update: ${{ steps.running_version_tag.outputs.is_running_version_tag_update }}
+
+  lint:
+    name: golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v8
+
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: actionlint
+        uses: raven-actions/actionlint@v2
+
+  docker:
+    name: Docker Images
+    needs: [lint, meta]
+    if: needs.meta.outputs.is_running_version_tag_update != 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Login to GHCR
+        if: needs.meta.outputs.is_pull_request != 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Hub
+        if: needs.meta.outputs.is_pull_request != 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Available platforms
+        run: echo ${{ steps.buildx.outputs.platforms }}
+
+      - name: Docker meta
+        id: docker_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ needs.meta.outputs.dockerhub_owner }}/${{ needs.meta.outputs.bin_name }}
+            ghcr.io/${{ needs.meta.outputs.ghcr_owner }}/${{ needs.meta.outputs.bin_name }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ env.DOCKER_PLATFORMS }}
+          builder: ${{ steps.buildx.outputs.name }}
+          push: ${{ needs.meta.outputs.is_pull_request != 'true' }}
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          build-args: |
+            BIN_NAME=${{ needs.meta.outputs.bin_name }}
+            BIN_VERSION=${{ needs.meta.outputs.bin_version }}
+
+      - name: Update Docker Hub description
+        if: needs.meta.outputs.is_release == 'true'
+        uses: peter-evans/dockerhub-description@v5
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ needs.meta.outputs.dockerhub_owner }}/${{ needs.meta.outputs.bin_name }}
+          readme-filepath: ./README.md
+          short-description: ${{ github.event.repository.description }}
+
+  binaries:
+    name: Binaries & Debian Packages
+    needs: [lint, meta]
+    if: needs.meta.outputs.is_running_version_tag_update != 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+      - name: Go version
+        run: go version
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
+          bundler-cache: true
+      - name: Ruby version
+        run: ruby --version
+      - name: Install fpm
+        run: |
+          gem install --no-document fpm -v "$FPM_VERSION"
+
+      - name: Build binaries & packages
+        run: make package
+      - name: Prepare release artifacts
+        working-directory: out/
+        run: |
+          mkdir ./gh-release
+          cp ./*.deb ./gh-release/
+          find . -name '${{ needs.meta.outputs.bin_name }}-*' -executable -type f -maxdepth 1 -print0 | xargs -0 -I {} tar --transform='flags=r;s|.*|${{ needs.meta.outputs.bin_name }}|' -czvf ./gh-release/{}.tar.gz {}
+      - name: Upload binaries & packages
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ needs.meta.outputs.bin_name }} Binary Artifacts
+          path: out/gh-release/*
+
+  release:
+    name: GitHub (Pre)Release
+    needs: [meta, binaries]
+    if: >-
+      needs.meta.outputs.is_release == 'true' ||
+      needs.meta.outputs.is_prerelease == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download binaries & packages
+        uses: actions/download-artifact@v5
+        with:
+          name: ${{ needs.meta.outputs.bin_name }} Binary Artifacts
+          path: out
+      - name: List artifacts
+        working-directory: out
+        run: ls -R
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: out/${{ needs.meta.outputs.bin_name }}-*
+          prerelease: ${{ needs.meta.outputs.is_prerelease == 'true' }}
+          fail_on_unmatched_files: true
+          generate_release_notes: true
+
+  tags:
+    name: Update Release Tags
+    needs: [meta, release]
+    if: needs.meta.outputs.is_release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+      - name: Update running major/minor version tags
+        uses: sersoft-gmbh/running-release-tags-action@v3
+        with:
+          fail-on-non-semver-tag: true
+          create-release: false
+          update-full-release: false
+
+  aptly:
+    name: Aptly
+    needs: [meta, binaries]
+    if: needs.meta.outputs.is_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download binaries & packages
+        uses: actions/download-artifact@v5
+        with:
+          name: ${{ needs.meta.outputs.bin_name }} Binary Artifacts
+          path: out
+      - name: List artifacts
+        run: ls -R
+        working-directory: out
+
+      - name: Login to Tailscale
+        uses: tailscale/github-action@v3
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:github-actions
+
+      - name: Push to Aptly Repo
+        shell: bash
+        run: |
+          set -x
+          for DEB in out/*.deb; do
+            curl -u "${{ secrets.APTLY_CRED }}" \
+              -fsS -X POST \
+              -F file=@"${DEB}" \
+              "${{ secrets.APTLY_API }}/files/${{ needs.meta.outputs.bin_name }}-${{ needs.meta.outputs.bin_version }}"
+          done
+          curl -u "${{ secrets.APTLY_CRED }}" \
+            -fsS -X POST \
+            "${{ secrets.APTLY_API }}/repos/${{ needs.meta.outputs.aptly_repo_name }}/file/${{ needs.meta.outputs.bin_name }}-${{ needs.meta.outputs.bin_version }}?forceReplace=1"
+
+      - name: Update Published Aptly Repo
+        run: |
+          set -x
+          curl -u "${{ secrets.APTLY_CRED }}" \
+            -fsS -X PUT \
+            -H 'Content-Type: application/json' \
+            --data '{"ForceOverwrite": true}' \
+            "${{ secrets.APTLY_API }}/publish/${{ needs.meta.outputs.aptly_publish_prefix }}/${{ needs.meta.outputs.aptly_dist }}?_async=true"
+
+  homebrew:
+    name: Update Homebrew Tap
+    needs: [meta, binaries]
+    if: needs.meta.outputs.is_release == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Release to ${{ needs.meta.outputs.brewtap_owner }}/${{ needs.meta.outputs.brewtap_name }} tap
+        uses: Justintime50/homebrew-releaser@v2
+        with:
+          homebrew_owner: ${{ needs.meta.outputs.brewtap_owner }}
+          homebrew_tap: homebrew-${{ needs.meta.outputs.brewtap_name }}
+          formula_folder: ${{ needs.meta.outputs.brewtap_formula_dir }}
+          update_readme_table: true
+          github_token: ${{ secrets.HOMEBREW_RELEASER_PAT }}
+          commit_owner: homebrew-releaser-bot
+          commit_email: homebrew-releaser-bot@users.noreply.github.com
+          target_darwin_amd64: true
+          target_darwin_arm64: true
+          target_linux_amd64: true
+          target_linux_arm64: true
+          version: v${{ needs.meta.outputs.bin_version }}
+          install: 'bin.install "${{ needs.meta.outputs.bin_name }}"'
+          test: 'assert_match("${{ needs.meta.outputs.bin_version }}", shell_output("#{bin}/${{ needs.meta.outputs.bin_name }} -version"))'
+
+  ntfy:
+    name: Ntfy
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    needs: [meta, lint, docker, binaries, release, aptly, homebrew]
+    steps:
+      - name: Send success notification
+        uses: niniyas/ntfy-action@V1.0.5
+        if: ${{ !contains(needs.*.result, 'failure') && (needs.meta.outputs.is_release == 'true' || needs.meta.outputs.is_prerelease == 'true') }}
+        with:
+          url: "https://ntfy.cdzombak.net"
+          topic: "gha-builds"
+          priority: 3
+          headers: '{"authorization": "Bearer ${{ secrets.NTFY_TOKEN }}"}'
+          tags: white_check_mark
+          title: ${{ github.event.repository.name }} ${{ needs.meta.outputs.bin_version }} available
+          details: ${{ github.event.repository.name }} version ${{ needs.meta.outputs.bin_version }} is now available.
+      - name: Send failure notification
+        uses: niniyas/ntfy-action@V1.0.5
+        if: ${{ contains(needs.*.result, 'failure') }}
+        with:
+          url: "https://ntfy.cdzombak.net"
+          topic: "gha-builds"
+          priority: 3
+          headers: '{"authorization": "Bearer ${{ secrets.NTFY_TOKEN }}"}'
+          tags: no_entry
+          title: ${{ github.event.repository.name }} ${{ needs.meta.outputs.bin_version }} build failed
+          details: Build failed for ${{ github.event.repository.name }} version ${{ needs.meta.outputs.bin_version }}.

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 creds.yml
 flickr-exporter
 flickr-export
+out/

--- a/Makefile
+++ b/Makefile
@@ -16,37 +16,39 @@ all: clean build-linux-amd64 build-linux-arm64 build-linux-386 build-linux-armv7
 clean: ## Remove build products (./out)
 	rm -rf ./out
 
-.PHONY: build
-build: ## Build for the current platform & architecture to ./out
+out:
 	mkdir -p out
+
+.PHONY: build
+build: | out ## Build for the current platform & architecture to ./out
 	env CGO_ENABLED=0 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME} .
 
 .PHONY: build-linux-amd64
-build-linux-amd64: ## Build for Linux/amd64 to ./out
+build-linux-amd64: | out ## Build for Linux/amd64 to ./out
 	env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME}-${BIN_VERSION}-linux-amd64 .
 
 .PHONY: build-linux-arm64
-build-linux-arm64: ## Build for Linux/arm64 to ./out
+build-linux-arm64: | out ## Build for Linux/arm64 to ./out
 	env CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME}-${BIN_VERSION}-linux-arm64 .
 
 .PHONY: build-linux-386
-build-linux-386: ## Build for Linux/386 to ./out
+build-linux-386: | out ## Build for Linux/386 to ./out
 	env CGO_ENABLED=0 GOOS=linux GOARCH=386 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME}-${BIN_VERSION}-linux-386 .
 
 .PHONY: build-linux-armv7
-build-linux-armv7: ## Build for Linux/armv7 to ./out
+build-linux-armv7: | out ## Build for Linux/armv7 to ./out
 	env CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=7 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME}-${BIN_VERSION}-linux-armv7 .
 
 .PHONY: build-linux-armv6
-build-linux-armv6: ## Build for Linux/armv6 to ./out
+build-linux-armv6: | out ## Build for Linux/armv6 to ./out
 	env CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME}-${BIN_VERSION}-linux-armv6 .
 
 .PHONY: build-darwin-amd64
-build-darwin-amd64: ## Build for macOS/amd64 to ./out
+build-darwin-amd64: | out ## Build for macOS/amd64 to ./out
 	env CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME}-${BIN_VERSION}-darwin-amd64 .
 
 .PHONY: build-darwin-arm64
-build-darwin-arm64: ## Build for macOS/arm64 to ./out
+build-darwin-arm64: | out ## Build for macOS/arm64 to ./out
 	env CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME}-${BIN_VERSION}-darwin-arm64 .
 
 .PHONY: package

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,56 @@
-# Makefile for flickr-exporter
+SHELL:=/usr/bin/env bash
 
-# Binary name
-BINARY = flickr-exporter
-BIN_VERSION := $(shell ./.version.sh)
+# nb. homebrew-releaser assumes the program name is == the repository name
+BIN_NAME:=flickr-exporter
+BIN_VERSION:=$(shell ./.version.sh)
 
-# Go parameters
-GOCMD = go
-GOBUILD = $(GOCMD) build
-GOCLEAN = $(GOCMD) clean
+default: help
+.PHONY: help  # via https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
+help: ## Print help
+	@grep -E '^[a-zA-Z_/-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-# Build target
-all: build
+.PHONY: all
+all: clean build-linux-amd64 build-linux-arm64 build-linux-386 build-linux-armv7 build-linux-armv6 build-darwin-amd64 build-darwin-arm64 ## Build for macOS (amd64, arm64) and Linux (amd64, 386, arm64, armv7, armv6)
 
-build:
-	$(GOBUILD) -ldflags="-X main.version=$(BIN_VERSION)" -o $(BINARY) -v
+.PHONY: clean
+clean: ## Remove build products (./out)
+	rm -rf ./out
 
-# Clean target - removes only the binary, not downloaded photos
-clean:
-	$(GOCLEAN)
-	rm -f $(BINARY)
+.PHONY: build
+build: ## Build for the current platform & architecture to ./out
+	mkdir -p out
+	env CGO_ENABLED=0 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME} .
 
-.PHONY: all build clean
+.PHONY: build-linux-amd64
+build-linux-amd64: ## Build for Linux/amd64 to ./out
+	env CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME}-${BIN_VERSION}-linux-amd64 .
+
+.PHONY: build-linux-arm64
+build-linux-arm64: ## Build for Linux/arm64 to ./out
+	env CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME}-${BIN_VERSION}-linux-arm64 .
+
+.PHONY: build-linux-386
+build-linux-386: ## Build for Linux/386 to ./out
+	env CGO_ENABLED=0 GOOS=linux GOARCH=386 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME}-${BIN_VERSION}-linux-386 .
+
+.PHONY: build-linux-armv7
+build-linux-armv7: ## Build for Linux/armv7 to ./out
+	env CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=7 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME}-${BIN_VERSION}-linux-armv7 .
+
+.PHONY: build-linux-armv6
+build-linux-armv6: ## Build for Linux/armv6 to ./out
+	env CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=6 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME}-${BIN_VERSION}-linux-armv6 .
+
+.PHONY: build-darwin-amd64
+build-darwin-amd64: ## Build for macOS/amd64 to ./out
+	env CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME}-${BIN_VERSION}-darwin-amd64 .
+
+.PHONY: build-darwin-arm64
+build-darwin-arm64: ## Build for macOS/arm64 to ./out
+	env CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags="-X main.version=${BIN_VERSION}" -o ./out/${BIN_NAME}-${BIN_VERSION}-darwin-arm64 .
+
+.PHONY: package
+package: all ## Build all binaries + .deb packages to ./out (requires fpm: https://fpm.readthedocs.io)
+	fpm -t deb -v ${BIN_VERSION} -p ./out/${BIN_NAME}-${BIN_VERSION}-amd64.deb -a amd64 ./out/${BIN_NAME}-${BIN_VERSION}-linux-amd64=/usr/bin/${BIN_NAME}
+	fpm -t deb -v ${BIN_VERSION} -p ./out/${BIN_NAME}-${BIN_VERSION}-arm64.deb -a arm64 ./out/${BIN_NAME}-${BIN_VERSION}-linux-arm64=/usr/bin/${BIN_NAME}
+	fpm -t deb -v ${BIN_VERSION} -p ./out/${BIN_NAME}-${BIN_VERSION}-armhf.deb -a armhf ./out/${BIN_NAME}-${BIN_VERSION}-linux-armv6=/usr/bin/${BIN_NAME}


### PR DESCRIPTION
## Summary

Resolves #1. Adds a full GitHub Actions CI/CD pipeline mirroring [mqtt2influxdb's workflow](https://github.com/cdzombak/mqtt2influxdb/blob/main/.github/workflows/main.yml), with the same version/release logic and outputs.

**What's included:**
- **`.github/workflows/main.yml`** — CI workflow with jobs for: build metadata derivation, golangci-lint, actionlint, multi-platform Docker image builds (GHCR + Docker Hub), cross-compiled binaries + Debian packages, GitHub releases, running version tag updates, Aptly repo publishing, Homebrew tap updates, and ntfy notifications.
- **`Makefile`** — Replaced the simple single-target Makefile with the standard cross-compilation and packaging Makefile (7 platform targets + `make package` for `.deb` files via fpm). Build output now goes to `./out/` instead of the project root. All cross-build targets use an order-only prerequisite (`| out`) to ensure the output directory exists.
- **`.fpm`** — New fpm metadata file for Debian packaging (GPL-3.0, correct project description/URL).
- **`.gitignore`** — Added `out/` for the new build output directory.

The workflow was validated locally with `actionlint` and a successful `go build`.

## Updates since last revision

- **Homebrew test flag**: Fixed the Homebrew test assertion to use `--version` (double-dash, matching Cobra's convention) instead of `-version`.
- **Makefile `out/` prerequisite**: Added a shared `out` directory target (`mkdir -p out`) and referenced it as an order-only prerequisite from all `build-*` targets, so cross-builds no longer fail when `./out` doesn't exist.

## Review & Testing Checklist for Human

- [ ] **`docker` and `binaries` jobs are currently skipped** because they depend on `lint` passing, and golangci-lint fails on 6 pre-existing issues in `exporter.go` (5 unchecked error returns + 1 unused function). These exist on `main` today. The full build/package/Docker pipeline is untested in CI for this PR — consider fixing the lint issues (or adding a `.golangci.yml` to suppress them) before the first release so these jobs can actually run.
- [ ] **Verify required GitHub repo secrets are configured** (or will be before first release): `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN`, `TS_OAUTH_CLIENT_ID`, `TS_OAUTH_SECRET`, `APTLY_CRED`, `APTLY_API`, `HOMEBREW_RELEASER_PAT`, `NTFY_TOKEN`
- [ ] **Docker multi-arch builds with Alpine base**: The Dockerfile uses `alpine:latest` (needs `exiftool`), not `scratch` like mqtt2influxdb. Confirm the Docker build succeeds on all 5 target platforms (`linux/amd64,arm64,386,arm/v7,arm/v6`) — particularly that `apk add exiftool` works on arm/v6 and 386.
- [ ] **Test the release flow** by pushing a prerelease tag (e.g. `v0.1.0-rc.1`) after merge to validate the full pipeline without triggering Aptly/Homebrew publication.

### Notes
- The `make build` target now outputs to `./out/flickr-exporter` instead of `./flickr-exporter` in the project root. The old `.gitignore` entry for `flickr-exporter` is retained for backward compatibility.
- All conditional logic (prerelease vs. release, running version tag detection, PR-only builds) is carried over identically from the mqtt2influxdb reference workflow.
- The Homebrew test assertion uses `--version` (Cobra's standard double-dash flag). Cobra outputs in the format `flickr-exporter version X.Y.Z`, so `assert_match` against the version string should work correctly.

Link to Devin session: https://app.devin.ai/sessions/2eb5a63948974dec876e351881060127
Requested by: @cdzombak
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/cdzombak/flickr-exporter/pull/5" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a packaging specification for a new package ("flickr-exporter") with metadata and publish configuration.
  * Introduced a CI workflow for testing, multi-arch builds, packaging, release creation, and notifications.
  * Updated build system to produce versioned artifacts in an output directory, cross-compile for multiple platforms, and generate Debian packages.
  * Ignored the output directory in source control and configured automated distribution to container registries, an Apt repository, and Homebrew.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->