### PR TITLE
Add installation instructions & Docker usage details to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,19 +15,76 @@ A command-line tool to download and archive your Flickr photos with metadata pre
 - Downloads photos in their original resolution
 - Failed downloads are reported at the end of the process
 
-## Requirements & Building
+## Installation
 
 ### Requirements
-- Go 1.16 or later
-- ExifTool (for metadata writing)
-  - macOS: `brew install exiftool`
-  - Linux: `sudo apt-get install libimage-exiftool-perl`
-  - Windows: Download from https://exiftool.org
 
-### Building
-```bash
-go build -o flickr-exporter
+flickr-exporter requires [ExifTool](https://exiftool.org) for metadata writing:
+- macOS: `brew install exiftool`
+- Linux: `sudo apt-get install libimage-exiftool-perl`
+- Windows: Download from https://exiftool.org
+
+### macOS via Homebrew
+
+```shell
+brew install cdzombak/oss/flickr-exporter
 ```
+
+### Debian via apt repository
+
+[Install my Debian repository](https://www.dzombak.com/blog/2025/06/updated-instructions-for-installing-my-debian-package-repositories/) if you haven't already:
+
+```shell
+sudo mkdir -p /etc/apt/keyrings
+curl -fsSL https://dist.cdzombak.net/keys/dist-cdzombak-net.gpg -o /etc/apt/keyrings/dist-cdzombak-net.gpg
+sudo chmod 644 /etc/apt/keyrings/dist-cdzombak-net.gpg
+sudo mkdir -p /etc/apt/sources.list.d
+sudo curl -fsSL https://dist.cdzombak.net/cdzombak-oss.sources -o /etc/apt/sources.list.d/cdzombak-oss.sources
+sudo chmod 644 /etc/apt/sources.list.d/cdzombak-oss.sources
+sudo apt update
+```
+
+Then install `flickr-exporter` via `apt-get`:
+
+```shell
+sudo apt-get install flickr-exporter
+```
+
+### Manual installation from build artifacts
+
+Pre-built binaries for Linux and macOS on various architectures are downloadable from each [GitHub Release](https://github.com/cdzombak/flickr-exporter/releases). Debian packages for each release are available as well.
+
+### Build and install locally
+
+```shell
+git clone https://github.com/cdzombak/flickr-exporter.git
+cd flickr-exporter
+make build
+
+cp out/flickr-exporter $INSTALL_DIR
+```
+
+### Docker images
+
+Docker images are available for a variety of Linux architectures from [Docker Hub](https://hub.docker.com/r/cdzombak/flickr-exporter) and [GHCR](https://github.com/cdzombak/flickr-exporter/pkgs/container/flickr-exporter). Images are based on Alpine Linux and include ExifTool.
+
+Run them via, for example:
+
+```shell
+docker run --rm \
+  -v /path/to/creds.yml:/creds.yml \
+  -v /path/to/output:/output \
+  cdzombak/flickr-exporter:1 \
+  -c /creds.yml all -o /output
+
+docker run --rm \
+  -v /path/to/creds.yml:/creds.yml \
+  -v /path/to/output:/output \
+  ghcr.io/cdzombak/flickr-exporter:1 \
+  -c /creds.yml all -o /output
+```
+
+> **Note:** The `auth` subcommand requires interactive terminal input. Run authentication on the host first using a native binary, then mount the resulting credentials file into the container for export commands.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,18 @@ cp out/flickr-exporter $INSTALL_DIR
 
 Docker images are available for a variety of Linux architectures from [Docker Hub](https://hub.docker.com/r/cdzombak/flickr-exporter) and [GHCR](https://github.com/cdzombak/flickr-exporter/pkgs/container/flickr-exporter). Images are based on Alpine Linux and include ExifTool.
 
-Run them via, for example:
+#### Authentication via Docker
+
+The `auth` subcommand requires interactive terminal input. Run it with the `-it` flag and mount a volume for the credentials file:
+
+```shell
+docker run --rm -it \
+  -v /path/to/creddir:/creds \
+  cdzombak/flickr-exporter:1 \
+  auth -k YOUR_API_KEY -s YOUR_API_SECRET --save-creds /creds/creds.yml
+```
+
+#### Exporting photos via Docker
 
 ```shell
 docker run --rm \
@@ -83,8 +94,6 @@ docker run --rm \
   ghcr.io/cdzombak/flickr-exporter:1 \
   -c /creds.yml all -o /output
 ```
-
-> **Note:** The `auth` subcommand requires interactive terminal input. Run authentication on the host first using a native binary, then mount the resulting credentials file into the container for export commands.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

Replaces the old "Requirements & Building" section with a comprehensive "Installation" section modeled after the [lychee-ai-organizer README](https://github.com/cdzombak/lychee-ai-organizer/blob/main/README.md). Adds:

- **macOS via Homebrew** (`cdzombak/oss/flickr-exporter`)
- **Debian via apt repository** (with repo setup instructions referencing `dist.cdzombak.net`)
- **Manual installation from GitHub Releases**
- **Build and install locally** (using `make build`)
- **Docker images** with usage examples for both Docker Hub and GHCR, including volume mounts for credentials and output directory
- A note that `auth` must be run on the host first since it requires interactive terminal input

ExifTool remains listed as a top-level requirement (needed for all non-Docker install methods). The Docker section notes that images are Alpine-based and include ExifTool.

## Review & Testing Checklist for Human

- [ ] Verify the Homebrew tap path (`cdzombak/oss/flickr-exporter`) matches what's actually published in the tap repo
- [ ] Verify Docker Hub and GHCR image names (`cdzombak/flickr-exporter`, `ghcr.io/cdzombak/flickr-exporter`) exist and the `:1` tag is available
- [ ] Confirm the Debian package name installed via apt is `flickr-exporter` (derived from `.fpm` config)
- [ ] Check whether the Docker usage examples are practical — e.g., does mounting creds + output and running `all -o /output` work as expected in the container?

### Notes

- The Go version requirement ("Go 1.16 or later") was removed from the top-level requirements since it only applies to building from source. It could optionally be added back under the "Build and install locally" subsection.
- Docker images use `alpine:latest` (not `scratch`) because ExifTool requires Perl — the description reflects this.

Link to Devin session: https://app.devin.ai/sessions/d9ec1140c4d2462e86e17e7f1cea6bfa
Requested by: @cdzombak

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded installation instructions with multiple setup paths: Homebrew, Debian apt repository, GitHub Releases (pre-built binaries/packages), local build/install, and Docker images.
  * Documented ExifTool as a prerequisite for metadata writing.
  * Added Docker-specific guidance: interactive auth usage and mounting credentials into containers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->